### PR TITLE
Fix missing semicolon

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
         author = "";
-        authors[] = {"ACE Team", "Glowbal"}
+        authors[] = {"ACE Team", "Glowbal"};
         authorUrl = "http://ace3mod.com";
         VERSION_CONFIG;
     };


### PR DESCRIPTION
Fixed a missing semicolon

ErrorMessage: File z\apt\addons\main\config.cpp, line 9: /CfgPatches/apt_main.authors: 'a' encountered instead of ';'