### PR TITLE
Fix missing backslashes

### DIFF
--- a/extras/blank/script_component.hpp
+++ b/extras/blank/script_component.hpp
@@ -1,6 +1,6 @@
 #define COMPONENT blank
 #define COMPONENT_BEAUTIFIED Blank
-#include "z\proj_templ\addons\main\script_mod.hpp"
+#include "\z\proj_templ\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
@@ -15,4 +15,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_BLANK
 #endif
 
-#include "z\proj_templ\addons\main\script_macros.hpp"
+#include "\z\proj_templ\addons\main\script_macros.hpp"


### PR DESCRIPTION
Fixed the missing backslashes so it leads to the script_mod.hpp.

ErrorMessage: Include file z\apt\addons\test\z\apt\addons\main\script_mod.hpp not found.